### PR TITLE
Fix location of conf.py in readthedocs config

### DIFF
--- a/{{cookiecutter.project_slug}}/.readthedocs.yml
+++ b/{{cookiecutter.project_slug}}/.readthedocs.yml
@@ -6,13 +6,13 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.8
   install:
     - method: pip
-      path: .
+      path: .git@github.com:browniebroke/cookiecutter-pypackage.git
       extra_requirements:
         - docs


### PR DESCRIPTION
I had to do this to get the docs to build successfully in readthetodocs.io