### PR TITLE
Fix output file location for CodeCov to work

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install Dependencies
         run: poetry install
       - name: Test with Pytest
-        run: poetry run pytest --cov-report=xml
+        run: poetry run pytest --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
The CodeCov GitHub action needs the output file to be in the base directory, at least by default. Make sure it is written to the right place during CI.